### PR TITLE
msg.hex path fixed

### DIFF
--- a/rtl/jtgng/jtgng_char.v
+++ b/rtl/jtgng/jtgng_char.v
@@ -69,7 +69,7 @@ jtgng_ram #(.aw(10)) u_ram_high(
     .q      ( mem_high )
 );
 
-jtgng_ram #(.aw(10),.synfile("msg.hex"),.simfile("msg.bin")) u_ram_msg(
+jtgng_ram #(.aw(10),.synfile("../../msg.hex"),.simfile("msg.bin")) u_ram_msg(
     .clk    ( clk      ),
     .cen    ( cen6     ),
     .data   ( 8'd0     ),


### PR DESCRIPTION
Vivado 2024.1 wasn't able to find "msg.hex" file while initializing mem content in jtgng_ram.v - relevant change had to be made in jtgng_char.v where the "msg.hex" was referred. I'm not sure if this fix is needed in older versions of Vivado or when this core is used in other context than being a submodule of M2M porting project.

So in short, it may or may not be a good and required fix in any case.